### PR TITLE
strip ".x" version suffix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,8 @@
 Unreleased
 
 -   Fix old-style class issue in Python 2. :pr:`1`
+-   Account for a ".x" suffix on the project version. "1.1.x" will
+    be seen as "1.1" for hiding old log entries. :pr:`5`
 
 
 1.0.0


### PR DESCRIPTION
Pallets-Sphinx-Themes started reporting the docs version as "1.1.x" instead of "1.1.2.dev". That got parsed as a `LegacyVersion`, which sorts below other versions, so no old logs were being hidden. This change strips a ".x" suffix before parsing the version. It also omits the "Changelog" section if there are no hidden log entries.