### PR TITLE
allow log entry as first node

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Unreleased
 -   Fix old-style class issue in Python 2. :pr:`1`
 -   Account for a ".x" suffix on the project version. "1.1.x" will
     be seen as "1.1" for hiding old log entries. :pr:`5`
+-   Fix error when log entries are at the very top of a page before any
+    other content. :issue:`3`
 
 
 1.0.0

--- a/src/sphinxcontrib/log_cabinet.py
+++ b/src/sphinxcontrib/log_cabinet.py
@@ -40,7 +40,14 @@ def handle_doctree_resolved(app, doctree, docname):
     version = _parse_placeholder_version(app.config.version)
 
     for after, log in visitor.logs:
-        index = after.parent.index(after) + 1 if after is not None else 0
+        if after is None:
+            # log was the first element of a page
+            after = log[0]
+            index = 0
+        else:
+            # log came after other nodes on the page
+            index = after.parent.index(after) + 1
+
         del after.parent[index : index + len(log)]
 
         if not collapse_all:


### PR DESCRIPTION
When `.. versionadded`, etc. is the first node on a page, there is no node before it. In that case, replace the log entry in place, instead of inserting it after a non-existent node.

closes #3 