### PR TITLE
config is prefixed with log_cabinet_

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
     be seen as "1.1" for hiding old log entries. :pr:`5`
 -   Fix error when log entries are at the very top of a page before any
     other content. :issue:`3`
+-   Config is now prefixed with ``log_cabinet_`` instead of
+    ``changelog_``. The old names are deprecated. :pr:`7`
 
 
 1.0.0

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,7 @@ Enable:
 
 Configure:
 
-.. code-block:: python
+``log_cabinet_collapse_all``
 
-    # False means current changes and all deprecations are not collapsed
-    changelog_collapse_all = False
+    By default, current changes and deprecations are not collapsed. Set
+    this to ``True`` to collapse all changes.

--- a/src/sphinxcontrib/log_cabinet.py
+++ b/src/sphinxcontrib/log_cabinet.py
@@ -3,12 +3,14 @@ from itertools import groupby
 from docutils import nodes
 from packaging.version import parse as parse_version
 from sphinx.addnodes import versionmodified
+from sphinx.util import logging
 
 __version__ = "1.0.1.dev"
+logger = logging.getLogger(__name__)
 
 
 def setup(app):
-    app.add_config_value("changelog_collapse_all", False, "html")
+    app.add_config_value("log_cabinet_collapse_all", False, "html")
     app.connect("doctree-resolved", handle_doctree_resolved)
     app.add_node(
         CollapsedLog,
@@ -18,7 +20,18 @@ def setup(app):
         man=(visit_nop, visit_nop),
         texinfo=(visit_nop, visit_nop),
     )
+    app.add_config_value("changelog_collapse_all", None, "")
+    app.connect("config-inited", check_deprecated_config)
     return {"version": __version__}
+
+
+def check_deprecated_config(app, config):
+    if config.changelog_collapse_all is not None:
+        logger.warning(
+            "The 'changelog_collapse_all' config has been renamed to"
+            " 'log_cabinet_collapse_all'. The old name will be removed"
+            " in version 1.1.0."
+        )
 
 
 def _parse_placeholder_version(value, placeholder="x"):


### PR DESCRIPTION
Match the config prefix with the package name. `changelog_collapse_all` is deprecated in favor of `log_cabinet_collapse_all`.