### PR TITLE
Add Sphinx Extension classifier

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ description = Organize changelog directives in Sphinx docs.
 long_description = file: README.rst
 classifiers =
     Development Status :: 5 - Production/Stable
+    Framework :: Sphinx :: Extension
     Intended Audience :: Developers
     License :: OSI Approved :: BSD License
     Operating System :: OS Independent


### PR DESCRIPTION
Add the Sphinx Extension PyPi classifier so that the extension shows up in the correct [PyPi filters](https://pypi.org/search/?c=Framework+%3A%3A+Sphinx+%3A%3A+Extension).